### PR TITLE
Fixed wrong comparison between movie_id and user_id

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -77,7 +77,7 @@ class RecommendationEngine:
         """Recommends up to movies_count top unrated movies to user_id
         """
         # Get pairs of (userID, movieID) for user_id unrated movies
-        user_unrated_movies_RDD = self.ratings_RDD.filter(lambda rating: not rating[1]==user_id).map(lambda x: (user_id, x[1]))
+        user_unrated_movies_RDD = self.ratings_RDD.filter(lambda rating: not rating[0]==user_id).map(lambda x: (user_id, x[1]))
         # Get predicted ratings
         ratings = self.__predict_ratings(user_unrated_movies_RDD).filter(lambda r: r[2]>=25).takeOrdered(movies_count, key=lambda x: -x[1])
 


### PR DESCRIPTION
Problem:
    In get_top_ratings() method, the filtering for the movies
    that weren't rated by the user_id is made based on comparison
    between movie_id and user_id.
Fix:
    Replaced movie_id field from ratings_RDD with the user_id field.
