### PR TITLE
Fix bug "GETing top recommendations shows the same movie #6"

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -77,7 +77,8 @@ class RecommendationEngine:
         """Recommends up to movies_count top unrated movies to user_id
         """
         # Get pairs of (userID, movieID) for user_id unrated movies
-        user_unrated_movies_RDD = self.ratings_RDD.filter(lambda rating: not rating[1]==user_id).map(lambda x: (user_id, x[1]))
+        user_unrated_movies_rdd = self.movies_rdd.filter(lambda rating: not rating[1] == user_id)\
+                                                 .map(lambda x: (user_id, x[0]))
         # Get predicted ratings
         ratings = self.__predict_ratings(user_unrated_movies_RDD).filter(lambda r: r[2]>=25).takeOrdered(movies_count, key=lambda x: -x[1])
 


### PR DESCRIPTION
Problem:
    Engine returns the same movie for the best recommendations.

Fix:
    Revert changes that were made by #5.

With these changes, the <i>get top recommendation feature</i> works fine. 

Example:
before 

```
$ curl http://0.0.0.0:5433/0/ratings/top/5
[["Citizen Kane (1941)", 9.007845861110559, 77], ["Citizen Kane (1941)", 9.007845861110559, 77],  
 ["Citizen Kane (1941)", 9.007845861110559, 77], ["Citizen Kane (1941)", 9.007845861110559, 77], 
 ["Citizen Kane (1941)", 9.007845861110559, 77], ]
```

after 

```
$ curl http://0.0.0.0:5433/0/ratings/top/5
[["Citizen Kane (1941)", 9.007845861110559, 77], 
 ["Spirited Away (Sen to Chihiro no kamikakushi) (2001)", 8.846219879097916, 72], 
 ["12 Angry Men (1957)", 8.78432643295096, 63], 
 ["Sunset Blvd. (a.k.a. Sunset Boulevard) (1950)", 8.767201279657312, 29], 
 ["\"Clockwork Orange", 8.699448955180992, 134]]
```
