### PR TITLE
Update engine.py

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -77,8 +77,8 @@ class RecommendationEngine:
         """Recommends up to movies_count top unrated movies to user_id
         """
         # Get pairs of (userID, movieID) for user_id unrated movies
-        user_unrated_movies_rdd = self.movies_rdd.filter(lambda rating: not rating[1] == user_id)\
-                                                 .map(lambda x: (user_id, x[0]))
+        user_unrated_movies_rdd = self.ratings_RDD.filter(lambda rating: not rating[0] == user_id)\
+                                                 .map(lambda x: (user_id, x[1])).distinct()
         # Get predicted ratings
         ratings = self.__predict_ratings(user_unrated_movies_RDD).filter(lambda r: r[2]>=25).takeOrdered(movies_count, key=lambda x: -x[1])
 


### PR DESCRIPTION
Fixing an issue reported several times, but not fixed entirely in issues #5 and #6 (and mentioned in issue #9 as a remaining bug).

The faulty logic mentioned in issue #5 was valid, but an error remained which led to the same items/movies recommended multiple times. This was due to the fact that the operations in line 80 resulted a non-unique RDD, meaning that the same movies are present multiple times. This is solved by adding the .distinct() operation, which removes duplicate entires.

Step-by-step:
1. self.ratings_RDD contains all user ratings
2. .filter(lambda rating: not rating[0] == user_id) eliminates all movies already rated by specified user, where rating[0] refers to the user_id column
3. .map(lambda x: (user_id, x[1])) puts all movie_ids in a (user_id, movie_id) format in a table (This is where a movie can exist multiple times!)
4. .distinct() removes all duplicates entries
